### PR TITLE
SEC-518: ignoring ssl_verify_callback return code warning 

### DIFF
--- a/lib/eligible.rb
+++ b/lib/eligible.rb
@@ -159,7 +159,8 @@ module Eligible
       open_timeout: 30,
       payload: payload,
       timeout: 80,
-      ssl_verify_callback: verify_certificate
+      ssl_verify_callback: verify_certificate,
+      ssl_verify_callback_warnings: false
     }
 
     begin

--- a/spec/lib/eligible_spec.rb
+++ b/spec/lib/eligible_spec.rb
@@ -1,4 +1,6 @@
 describe Eligible do
+  let(:response) {  double("response", body: "{\"success\": \"true\"}", code: 200) }
+
   it 'has a version number' do
     expect(Eligible::VERSION).to_not be_nil
   end
@@ -8,6 +10,12 @@ describe Eligible do
       Eligible.api_key = "foo"
       allow(Eligible).to receive(:valid_fingerprint?).and_return(false)
       expect { Eligible::Coverage.get({}) }.to raise_error(Eligible::APIConnectionError)
+    end
+
+    it 'should not warn about ignoring ssl_verify_callback return code' do
+      allow(Eligible).to receive(:valid_fingerprint?).and_return(true)
+      allow_any_instance_of(RestClient::Request).to receive(:process_result).and_return(response)
+      expect { Eligible::Coverage.get({}) }.not_to output("warning: ssl_verify_callback return code is ignored on OS X\npass :ssl_verify_callback_warnings => false to silence this\n").to_stderr
     end
 
     it 'warns when the fingerprint is overridden' do


### PR DESCRIPTION
On Mac OS, Rest client warns about ignoring ssl_verify_callback return code, while those are not used during SSL cert validation. If SSL certificate validation fails, an exception is raised to terminate the request.

Ignoring ssl_verify_callback warnings as part of the pull request.