### PR TITLE
Default Eligible::Payer.list params to empty hash.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2016-10-17  Eligible  <support@eligible.com>
+
+	* 2.7.0
+	- Updated Eligible::Payer.list to default to empty hash
+
 2016-08-31  Eligible  <support@eligible.com>
 	* 2.6.2
 	- New APIs added in testing mode, no public-facing changes
@@ -10,7 +15,7 @@
 	- Documentation updates for the endpoints
 
 2016-02-23  Eligible  <support@eligible.com>
-	
+
 	* 2.6.0
 	- Added new endpoints customer, original signature pdf and payer.
 	- Added specs

--- a/README.md
+++ b/README.md
@@ -561,8 +561,7 @@ response.to_hash
 ### List all the payers
 
 ```ruby
-response = Eligible::Payer.list({})
-response.collect { |payer| payer.to_hash }
+payers = Eligible::Payer.list.collect { |payer| payer.to_hash }
 ```
 
 ### View a single payer
@@ -579,7 +578,7 @@ response.to_hash
 params = { payer_id: '12345' }
 response = Eligible::Payer.search_options(params)
 response.to_hash
-``` 
+```
 
 ### Search options for all payers
 

--- a/lib/eligible/payer.rb
+++ b/lib/eligible/payer.rb
@@ -1,6 +1,6 @@
 module Eligible
   class Payer < APIResource
-    def self.list(params, api_key = nil)
+    def self.list(params = {}, api_key = nil)
       send_request(:get, api_url('payers'), api_key, params)
     end
 

--- a/lib/eligible/version.rb
+++ b/lib/eligible/version.rb
@@ -1,3 +1,3 @@
 module Eligible
-  VERSION = '2.6.2'.freeze
+  VERSION = '2.7.0'.freeze
 end

--- a/spec/lib/payer_spec.rb
+++ b/spec/lib/payer_spec.rb
@@ -23,6 +23,11 @@ describe 'Eligible::Payer' do
       allow(Eligible).to receive(:request).with(:get, '/payers.json', api_key, params).and_return([response, api_key])
       expect(Eligible::Payer.list(params, api_key)).to eq 'success'
     end
+
+    it 'defaults to an empty hash if no params are provided' do
+      allow(Eligible).to receive(:request).with(:get, '/payers.json', nil, {}).and_return([response, api_key])
+      expect(Eligible::Payer.list).to eq 'success'
+    end
   end
 
   describe '.search_options' do


### PR DESCRIPTION
When listing all payers there is no reason to have to provide an empty
hash. This commit defaults the params argument to an empty hash to make
it easier.
