### PR TITLE
Upgrading RestClient to 2.0

### DIFF
--- a/eligible.gemspec
+++ b/eligible.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency('rest-client', '~> 1.8')
+  gem.add_dependency('rest-client', '~> 2.0')
   gem.add_dependency('multi_json', '~> 1.7')
 
   gem.add_development_dependency('rake', '~> 10.5')


### PR DESCRIPTION
Tech debt fix: Upgrades Rest Client to latest.


### Upgrading to rest-client 2.0 from 1.x

Users are encouraged to upgrade to rest-client 2.0, which cleans up a number of
API warts and wrinkles, making rest-client generally more useful. Usage is
largely compatible, so many applications will be able to upgrade with no
changes.

### Overview of significant changes:

* requires Ruby >= 2.0
* `RestClient::Response` objects are a subclass of `String` rather than a
  Frankenstein monster. And `#body` or `#to_s` return a true `String` object.
* cleanup of exception classes, including new `RestClient::Exceptions::Timeout`
* improvements to handling of redirects: responses and history are properly
  exposed
* major changes to cookie support: cookie jars are used for browser-like
  behavior throughout
* encoding: Content-Type charset response headers are used to automatically set
  the encoding of the response string
* HTTP params: handling of GET/POST params is more consistent and sophisticated
  for deeply nested hash objects, and `ParamsArray` can be used to pass ordered
  params
* improved proxy support with per-request proxy configuration, plus the ability
  to disable proxies set by environment variables
* default request headers: rest-client sets `Accept: */*` and
  `User-Agent: rest-client/...`

See [history.md](https://github.com/rest-client/rest-client/blob/master/history.md) for a more complete description of changes.
