### PR TITLE
ENG-7507: Updating restclient version to 2.0.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2017-03-24 Eligible  <support@eligible.com>
+
+	* 2.8.2
+	- Upgrades internal rest-client dependency to 2.0.0 and higher
+
 2017-02-23 Eligible  <support@eligible.com>
 
 	* 2.8.1

--- a/eligible.gemspec
+++ b/eligible.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency('rest-client', '~> 2.0.1')
+  gem.add_dependency('rest-client', '~> 2.0.0')
   gem.add_dependency('multi_json', '~> 1.7')
 
   gem.add_development_dependency('rake', '~> 10.5')

--- a/lib/eligible/version.rb
+++ b/lib/eligible/version.rb
@@ -1,3 +1,3 @@
 module Eligible
-  VERSION = '2.8.1'.freeze
+  VERSION = '2.8.2'.freeze
 end


### PR DESCRIPTION
|JIRA    | [ENG-7507](https://eligible.atlassian.net/browse/ENG-7507)
|:-------|:-----------------------------------------------------------

### Description
A customer needs rest client 2.0.0 version as he has specific requirements. So, updating eligible gem to use that version of rest client

### Checklists

**Development and testing:**
- [x] All tests related to the changed code pass in development

**Pre-release and code review:**
- [x] CI build is green
- [x] CodeClimate does not see any new issues
- [x] "Ready for review" label attached to PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one Senior Engineer
- [x] JIRA issue has a link to this pull request